### PR TITLE
Fix single-precision transforms

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NonuniformFFTs"
 uuid = "cd96f58b-6017-4a02-bb9e-f4d81626177f"
 authors = ["Juan Ignacio Polanco <juan-ignacio.polanco@cnrs.fr>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 Bessels = "0e736298-9ec6-45e8-9647-e4fc86a2fe38"

--- a/src/Kernels/kaiser_bessel.jl
+++ b/src/Kernels/kaiser_bessel.jl
@@ -122,7 +122,7 @@ function optimal_kernel(::KaiserBesselKernel, h::HalfSupport{M}, Δx, σ) where 
     # Set the optimal kernel shape parameter given the wanted support M and the oversampling
     # factor σ. See Potts & Steidl 2003, eq. (5.12).
     γ = 0.980  # empirical "safety factor" which slightly improves accuracy, as in FINUFFT (where γ = 0.976)
-    β = oftype(Δx, M * π * (2 - 1 / σ)) * γ
+    β = oftype(Δx, M * π * (2 - 1 / σ) * γ)
     KaiserBesselKernelData(h, Δx, β)
 end
 

--- a/src/Kernels/kaiser_bessel_backwards.jl
+++ b/src/Kernels/kaiser_bessel_backwards.jl
@@ -92,7 +92,7 @@ function optimal_kernel(::BackwardsKaiserBesselKernel, h::HalfSupport{M}, Δx, �
     # Set the optimal kernel shape parameter given the wanted support M and the oversampling
     # factor σ. See Potts & Steidl 2003, eq. (5.12).
     γ = 0.995  # empirical "safety factor" which slightly improves accuracy, as in FINUFFT (where γ = 0.976)
-    β = oftype(Δx, M * π * (2 - 1 / σ)) * γ
+    β = oftype(Δx, M * π * (2 - 1 / σ) * γ)
     BackwardsKaiserBesselKernelData(h, Δx, β)
 end
 


### PR DESCRIPTION
This fixes the creation of NUFFT plans of `Float32` or `ComplexF32` data with certain spreading kernels, in particular with the default one (`BackwardsKaiserBesselKernel`).