### PR TITLE
Reduce compilation time when creating plans

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NonuniformFFTs"
 uuid = "cd96f58b-6017-4a02-bb9e-f4d81626177f"
 authors = ["Juan Ignacio Polanco <juan-ignacio.polanco@cnrs.fr>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 Bessels = "0e736298-9ec6-45e8-9647-e4fc86a2fe38"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ N = 256   # number of Fourier modes
 Np = 100  # number of non-uniform points
 
 # Generate some non-uniform random data
-T = Float64             # non-uniform data is real (can also be complex)
-xp = rand(T, Np) .* 2π  # non-uniform points in [0, 2π]
-vp = randn(T, Np)       # random values at points
+T = Float64                # non-uniform data is real (can also be complex)
+xp = rand(T, Np) .* T(2π)  # non-uniform points in [0, 2π]
+vp = randn(T, Np)          # random values at points
 
 # Create plan for data of type T
 plan_nufft = PlanNUFFT(T, N; m = HalfSupport(8))  # larger support increases accuracy
@@ -43,7 +43,7 @@ Np = 100  # number of non-uniform points
 
 # Generate some uniform random data
 T = Float64                        # non-uniform data is real (can also be complex)
-xp = rand(T, Np) .* 2π             # non-uniform points in [0, 2π]
+xp = rand(T, Np) .* T(2π)          # non-uniform points in [0, 2π]
 ûs = randn(Complex{T}, N ÷ 2 + 1)  # random values at points (we need to store roughly half the Fourier modes for complex-to-real transform)
 
 # Create plan for data of type T
@@ -70,10 +70,10 @@ Ns = (256, 256)  # number of Fourier modes in each direction
 Np = 1000        # number of non-uniform points
 
 # Generate some non-uniform random data
-T = Float64                                   # non-uniform data is real (can also be complex)
-d = length(Ns)                                # number of dimensions (d = 2 here)
-xp = [2π * rand(SVector{d, T}) for _ ∈ 1:Np]  # non-uniform points in [0, 2π]ᵈ
-vp = randn(T, Np)                             # random values at points
+T = Float64                                      # non-uniform data is real (can also be complex)
+d = length(Ns)                                   # number of dimensions (d = 2 here)
+xp = [T(2π) * rand(SVector{d, T}) for _ ∈ 1:Np]  # non-uniform points in [0, 2π]ᵈ
+vp = randn(T, Np)                                # random values at points
 
 # Create plan for data of type T
 plan_nufft = PlanNUFFT(T, Ns; m = HalfSupport(8))
@@ -102,8 +102,8 @@ Np = 100  # number of non-uniform points
 ntrans = Val(3)  # number of simultaneous transforms
 
 # Generate some non-uniform random data
-T = Float64             # non-uniform data is real (can also be complex)
-xp = rand(T, Np) .* 2π  # non-uniform points in [0, 2π]
+T = Float64                # non-uniform data is real (can also be complex)
+xp = rand(T, Np) .* T(2π)  # non-uniform points in [0, 2π]
 vp = ntuple(_ -> randn(T, Np), ntrans)  # random values at points (one vector per transformed quantity)
 
 # Create plan for data of type T

--- a/src/Kernels/kaiser_bessel.jl
+++ b/src/Kernels/kaiser_bessel.jl
@@ -96,7 +96,7 @@ In other words, FFTs must be performed over a grid of size ``Ñ = σN`` where ``
 size of the grid of interest.
 """
 struct KaiserBesselKernelData{
-        M, T <: AbstractFloat, ApproxCoefs <: AbstractArray{T},
+        M, T <: AbstractFloat, ApproxCoefs <: NTuple,
     } <: AbstractKernelData{KaiserBesselKernel, M, T}
     Δx :: T  # grid spacing
     σ  :: T  # equivalent kernel width (for comparison with Gaussian)

--- a/src/Kernels/kaiser_bessel_backwards.jl
+++ b/src/Kernels/kaiser_bessel_backwards.jl
@@ -68,7 +68,7 @@ end
 BackwardsKaiserBesselKernel() = BackwardsKaiserBesselKernel(nothing)
 
 struct BackwardsKaiserBesselKernelData{
-        M, T <: AbstractFloat, ApproxCoefs <: AbstractArray{T},
+        M, T <: AbstractFloat, ApproxCoefs <: NTuple,
     } <: AbstractKernelData{BackwardsKaiserBesselKernel, M, T}
     Δx :: T  # grid spacing
     σ  :: T  # equivalent kernel width (for comparison with Gaussian)

--- a/src/Kernels/piecewise_polynomial.jl
+++ b/src/Kernels/piecewise_polynomial.jl
@@ -14,10 +14,12 @@
 #   function in the complex plane. This is inspired by a paper by Shamshigar, Bagge &
 #   Tornberg (J. Chem. Phys. 2021).
 
-using StaticArrays: SVector, SMatrix, MMatrix
+using StaticArrays: SVector
 
 function solve_polynomial_coefficients(f::F, ::Type{T}, ::Val{N}) where {F, T, N}
-    A = MMatrix{N, N, T, N^2}(undef)
+    # Note: we could use a MMatrix{N,N,T} to avoid some allocations, but that greatly
+    # increases the compilation time...
+    A = Matrix{T}(undef, N, N)
     xs = SVector(ntuple(i -> cospi(T(i - 1/2) / N), Val(N)))  # interpolate at Chebyshev points
     ys = map(f, xs)
     xs_pow = zero(xs) .+ true  # = 1
@@ -25,7 +27,13 @@ function solve_polynomial_coefficients(f::F, ::Type{T}, ::Val{N}) where {F, T, N
         A[:, j] = xs_pow
         xs_pow = xs_pow .* xs
     end
-    SMatrix(A) \ ys
+    NTuple{N}(A \ ys)
+end
+
+function transpose_tuple_of_tuples(cs::NTuple{L, NTuple{N}}) where {L, N}
+    ntuple(Val(N)) do j
+        ntuple(i -> cs[i][j], Val(L))
+    end
 end
 
 # L = 2M: total number of subintervals in [-1, 1].
@@ -33,33 +41,33 @@ function solve_piecewise_polynomial_coefficients(
         f::F, ::Type{T}, ::Val{M}, ::Val{N},
     ) where {F, T, M, N}
     L = 2M
-    cs = MMatrix{N, L, T, L * N}(undef)
-    for j ∈ 1:L
+    cs = ntuple(Val(L)) do j
         # Note: we go from right (+1) to left (-1).
         h = 1 - 2 * (j - 1/2) / L  # midpoint of interval
         δ = 1 / L                  # half-width of interval
-        cs[:, j] = solve_polynomial_coefficients(T, Val(N)) do x
+        solve_polynomial_coefficients(T, Val(N)) do x
             y = h + x * δ  # Transform x ∈ [-1, 1] → y ∈ [h - δ, h + δ]
             f(y)
         end
     end
-    SMatrix(cs)'
+    transpose_tuple_of_tuples(cs)
 end
 
-function evaluate_piecewise(δ, cs::SMatrix)
-    L, _ = size(cs)
+function evaluate_piecewise(δ, cs::NTuple)
+    L = length(first(cs))
     # @assert 0 ≤ δ < 2/L == 1/M
     x = L * δ - 1  # in [-1, 1]
-    Tuple(evaluate_horner(x, cs))
+    evaluate_horner(x, cs)
 end
 
 # Evaluate multiple polynomials at the same location `x` using Horner's method.
 # This is very fast due to SIMD vectorisation.
-function evaluate_horner(x, cs::SMatrix)
-    ys = cs[:, end]
-    js = reverse(axes(cs, 2)[1:end - 1])
+function evaluate_horner(x, cs::NTuple)
+    ys = @inbounds SVector(cs[end])
+    js = @inbounds reverse(eachindex(cs)[1:end - 1])
     for j ∈ js
-        ys = muladd(x, ys, cs[:, j])
+        cj = @inbounds SVector(cs[j])
+        ys = muladd(x, ys, cj)
     end
-    ys
+    Tuple(ys)
 end


### PR DESCRIPTION
This reduces compilation time by avoiding the use of large static matrices (`MMatrix{L, N}`) for obtaining the polynomial approximation coefficients. Note that this only affects the `(Backwards)KaiserBesselKernel` spreading functions for which fast polynomial approximation is used.