### PR TITLE
Change parallel sortperm implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
+    env:
+      JULIA_NUM_THREADS: 2
     strategy:
       fail-fast: true
       matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -5,21 +5,21 @@ version = "0.3.5"
 
 [deps]
 Bessels = "0e736298-9ec6-45e8-9647-e4fc86a2fe38"
+Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
 Bessels = "0.2"
+Bumper = "0.6"
 FFTW = "1.7"
 LinearAlgebra = "1.9"
 Static = "0.8"
 StaticArrays = "1.7"
 StructArrays = "0.6"
-ThreadsX = "0.1"
 TimerOutputs = "0.5"
 julia = "1.9"

--- a/src/NonuniformFFTs.jl
+++ b/src/NonuniformFFTs.jl
@@ -33,6 +33,7 @@ export
     exec_type1!,
     exec_type2!
 
+include("sorting.jl")
 include("blocking.jl")
 include("plan.jl")
 include("set_points.jl")

--- a/src/blocking.jl
+++ b/src/blocking.jl
@@ -1,5 +1,3 @@
-using ThreadsX: ThreadsX
-
 abstract type AbstractBlockData end
 
 # Dummy type used when blocking has been disabled in the NUFFT plan.
@@ -140,12 +138,8 @@ function set_points!(bd::BlockData, points, xp, timer)
     # are concentrated, improving load balance.
     map_blocks_to_threads!(bd.blocks_per_thread, cumulative_npoints_per_block)
 
-    @timeit timer "Sort" if Threads.nthreads() == 1
-        # This is the same as sortperm! but seems to be faster.
-        sort!(pointperm; by = i -> @inbounds(blockidx[i]), alg = QuickSort)
-        # sortperm!(pointperm, blockidx; alg = QuickSort)
-    else
-        ThreadsX.sort!(pointperm; by = i -> @inbounds(blockidx[i]), alg = ThreadsX.QuickSort())
+    @timeit timer "Sort" begin
+        quicksort_perm!(pointperm, blockidx)
     end
 
     # Write sorted points into `points`.

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -1,0 +1,71 @@
+# Threaded permsort! implementation based on quicksort, adapted from the parallel sort!
+# implementation by Nikos Pitsianis in
+# https://discourse.julialang.org/t/parallel-quicksort-openmp/88499/18.
+#
+# This is used when applying blocking (see set_points!(::BlockData, ...)).
+
+using Bumper: @no_escape, @alloc
+
+const QUICKSORT_SEQ_THRESH = 1 << 9
+
+@inline function partition_perm!(ix, A, pivot, left, right)
+    @inbounds while left ≤ right
+        while A[left] < pivot
+            left += 1
+        end
+        while A[right] > pivot
+            right -= 1
+        end
+        if left ≤ right
+            A[left], A[right] = A[right], A[left]
+            ix[left], ix[right] = ix[right], ix[left]
+            left += 1
+            right -= 1
+        end
+    end
+    (left, right)
+end
+
+@inline function quicksort_perm!(
+        ix, A, lo = firstindex(A), hi = lastindex(A);
+        nthreads = Threads.nthreads(),
+    )
+    len = hi - lo + 1
+    @inbounds if len ≤ 0
+        return ix
+    elseif len ≤ 32
+        # Use sequential sortperm! from Base.
+        ix_local = @view ix[lo:hi]
+        A_local = @view A[lo:hi]
+        quicksort_perm_base_case!(ix_local, A_local)
+    else
+        pivot = A[(lo + hi) >>> 1]
+        left, right = partition_perm!(ix, A, pivot, lo, hi)
+        if nthreads == 1 || len < QUICKSORT_SEQ_THRESH
+            quicksort_perm!(ix, A, lo, right)
+            quicksort_perm!(ix, A, left, hi)
+        else
+            t = Threads.@spawn quicksort_perm!(ix, A, lo, right)
+            quicksort_perm!(ix, A, left, hi)
+            wait(t)
+        end
+    end
+    ix
+end
+
+@inline function quicksort_perm_base_case!(ix, A)
+    Base.require_one_based_indexing(ix)
+    @no_escape begin
+        I = eltype(ix)
+        perm = @alloc(I, length(ix))
+        ix_sorted = @alloc(I, length(ix))
+        sortperm!(perm, A; alg = QuickSort)
+        @inbounds for j ∈ eachindex(perm)
+            ix_sorted[j] = ix[perm[j]]
+        end
+        @inbounds for j ∈ eachindex(perm)
+            ix[j] = ix_sorted[j]
+        end
+    end
+    ix
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,8 @@ macro includetest(path::String)
     ex
 end
 
+@info "Running tests on $(Threads.nthreads()) threads"
+
 @testset "NonuniformFFTs.jl" begin
     @includetest "accuracy.jl"
     @includetest "multidimensional.jl"


### PR DESCRIPTION
Performance is similar to the previous ThreadsX.jl based implementation. The new implementation allocates less.