### PR TITLE
Precompile common workloads with PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,14 @@
 name = "NonuniformFFTs"
 uuid = "cd96f58b-6017-4a02-bb9e-f4d81626177f"
 authors = ["Juan Ignacio Polanco <juan-ignacio.polanco@cnrs.fr>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 Bessels = "0e736298-9ec6-45e8-9647-e4fc86a2fe38"
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
@@ -18,6 +19,7 @@ Bessels = "0.2"
 Bumper = "0.6"
 FFTW = "1.7"
 LinearAlgebra = "1.9"
+PrecompileTools = "1.2"
 Static = "0.8"
 StaticArrays = "1.7"
 StructArrays = "0.6"

--- a/src/NonuniformFFTs.jl
+++ b/src/NonuniformFFTs.jl
@@ -248,29 +248,29 @@ end
 @setup_workload let
     kernels = [default_kernel()]  # only precompile for default kernel
     ndims_all = 1:3
-    # ntrans_all = 1:3
-    ntrans_all = 1:1
-    ms = map(HalfSupport, 2:8)
+    ms = map(HalfSupport, 2:2:8)
     # Ts = [Float32, Float64, ComplexF32, ComplexF64]
     Ts = [Float64, ComplexF64]
     σ = 1.25
-    for kernel ∈ kernels, m ∈ ms, T ∈ Ts, ndims ∈ ndims_all, ntrans ∈ ntrans_all
+    for kernel ∈ kernels, m ∈ ms, T ∈ Ts, ndims ∈ ndims_all
         dims = ntuple(_ -> 12, ndims)  # σN = 16
-        ntransforms = Val(ntrans)
         Np = 16  # number of non-uniform points
         xs = ntuple(_ -> rand(real(T), Np) .* 2π, ndims)
-        qs = ntuple(_ -> randn(T, Np), ntrans)
         Ns = ntuple(ndims) do i
             N = dims[i]
             (i == 1 && T <: Real) ? ((N + 2) >> 1) : N
         end
         C = complex(T)
-        uhat = ntuple(_ -> Array{C}(undef, Ns), ntrans)
-        @compile_workload begin
-            plan = PlanNUFFT(T, dims; ntransforms, m, σ, kernel)
-            set_points!(plan, xs)
-            exec_type1!(uhat, plan, qs)
-            exec_type2!(qs, plan, uhat)
+        for ntrans ∈ (1, ndims)  # number of simultaneous transforms
+            ntransforms = Val(ntrans)
+            qs = ntuple(_ -> randn(T, Np), ntransforms)
+            uhat = ntuple(_ -> Array{C}(undef, Ns), ntransforms)
+            @compile_workload begin
+                plan = PlanNUFFT(T, dims; ntransforms, m, σ, kernel)
+                set_points!(plan, xs)
+                exec_type1!(uhat, plan, qs)
+                exec_type2!(qs, plan, uhat)
+            end
         end
     end
 end

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -218,7 +218,7 @@ end
 function PlanNUFFT(
         ::Type{T}, Ns::Dims, h::HalfSupport;
         ntransforms = Val(1),
-        kernel::AbstractKernel = BackwardsKaiserBesselKernel(),
+        kernel::AbstractKernel = default_kernel(),
         σ::Real = real(T)(2), kws...,
     ) where {T <: Number}
     R = real(T)


### PR DESCRIPTION
Precompilation can take a bit long, since we specialise on a lot of things (the choice of kernel, the kernel support size, the number of simultaneous transforms, the number of dimensions, the element types...). This means there's a lot of possible combinations, which can make the precompilation times (and the resulting binary sizes) explode. So we only precompile some of the possible combinations (e.g. only for the default kernel).