### PR TITLE
Parallelise deconvolutions

### DIFF
--- a/src/NonuniformFFTs.jl
+++ b/src/NonuniformFFTs.jl
@@ -73,7 +73,7 @@ end
 
 # We find it's faster to use a low-level call to memset (as opposed to a `for` loop, or
 # `fill!`), parallelised over all threads.
-# In fact, this mostly seems to be the case for complex data, while for real data usign
+# In fact, this mostly seems to be the case for complex data, while for real data using
 # `fill!` gives the same performance...
 # Using memset only makes sense if the arrays are contiguous in memory (DenseArray).
 function fill_with_zeros_threaded!(
@@ -89,7 +89,7 @@ function fill_with_zeros_threaded!(
         b = ((n - 0) * length(inds)) ÷ nthreads
         # checkbounds(inds, (a + 1):b)
         for us ∈ us_all
-            # This requires ûs to be a DenseArray (contiguous in memory).
+            # This requires `us` to be a DenseArray (contiguous in memory).
             p = pointer(us, a + 1)
             n = (b - a) * sizeof(eltype(us))
             val = zero(Cint)

--- a/src/NonuniformFFTs.jl
+++ b/src/NonuniformFFTs.jl
@@ -36,6 +36,10 @@ export
 
 default_kernel() = BackwardsKaiserBesselKernel()
 
+# This is used at several places instead of getindex (inside of a `map`) to be sure that the
+# @inbounds is applied.
+inbounds_getindex(v, i) = @inbounds v[i]
+
 include("sorting.jl")
 include("blocking.jl")
 include("plan.jl")
@@ -214,8 +218,6 @@ function non_oversampled_indices!(
     end
     indmap
 end
-
-inbounds_getindex(v, i) = @inbounds v[i]
 
 function copy_deconvolve_to_non_oversampled!(
         ŵs_all::NTuple{C}, ûs_all::NTuple{C}, index_map, ϕ̂s, normfactor,

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -88,8 +88,8 @@ function interpolate_from_arrays(
     imap_first, imap_tail = first(inds_mapping), Base.tail(inds_mapping)
     @inbounds for J_tail ∈ CartesianIndices(inds_tail)
         js_tail = Tuple(J_tail)
-        is_tail = map(getindex, imap_tail, js_tail)
-        gs_tail = map(getindex, vals_tail, js_tail)
+        is_tail = map(inbounds_getindex, imap_tail, js_tail)
+        gs_tail = map(inbounds_getindex, vals_tail, js_tail)
         gprod_tail = prod(gs_tail)
         for j ∈ inds_first
             i = imap_first[j]
@@ -116,7 +116,7 @@ function interpolate_from_arrays_blocked(
     vals_first, vals_tail = first(vals), Base.tail(vals)
     @inbounds for J_tail ∈ CartesianIndices(inds_tail)
         js_tail = Tuple(J_tail)
-        gs_tail = map(getindex, vals_tail, js_tail)
+        gs_tail = map(inbounds_getindex, vals_tail, js_tail)
         gprod_tail = prod(gs_tail)
         for j ∈ inds_first
             I = Is[j, js_tail...]
@@ -202,7 +202,7 @@ function copy_to_block!(
     inds_wrapped_first, inds_wrapped_tail = first(inds_wrapped), Base.tail(inds_wrapped)
     @inbounds for I_tail ∈ CartesianIndices(inds_tail)
         is_tail = Tuple(I_tail)
-        js_tail = map(getindex, inds_wrapped_tail, is_tail)
+        js_tail = map(inbounds_getindex, inds_wrapped_tail, is_tail)
         for i ∈ inds_first
             j = inds_wrapped_first[i]
             for (us, ws) ∈ zip(us_all, block)

--- a/src/spreading.jl
+++ b/src/spreading.jl
@@ -189,7 +189,7 @@ function add_from_block!(
     inds_wrapped_first, inds_wrapped_tail = first(inds_wrapped), Base.tail(inds_wrapped)
     @inbounds for I_tail ∈ CartesianIndices(inds_tail)
         is_tail = Tuple(I_tail)
-        js_tail = map(getindex, inds_wrapped_tail, is_tail)
+        js_tail = map(inbounds_getindex, inds_wrapped_tail, is_tail)
         for i ∈ inds_first
             j = inds_wrapped_first[i]
             for (us, ws) ∈ zip(us_all, block)
@@ -212,8 +212,8 @@ function spread_onto_arrays!(
     imap_first, imap_tail = first(inds_mapping), Base.tail(inds_mapping)
     @inbounds for J_tail ∈ CartesianIndices(inds_tail)
         js_tail = Tuple(J_tail)
-        is_tail = map(getindex, imap_tail, js_tail)
-        gs_tail = map(getindex, vals_tail, js_tail)
+        is_tail = map(inbounds_getindex, imap_tail, js_tail)
+        gs_tail = map(inbounds_getindex, vals_tail, js_tail)
         gprod_tail = prod(gs_tail)
         for j ∈ inds_first
             i = imap_first[j]
@@ -240,7 +240,7 @@ function spread_onto_arrays_blocked!(
     vals_first, vals_tail = first(vals), Base.tail(vals)
     @inbounds for J_tail ∈ CartesianIndices(inds_tail)
         js_tail = Tuple(J_tail)
-        gs_tail = map(getindex, vals_tail, js_tail)
+        gs_tail = map(inbounds_getindex, vals_tail, js_tail)
         gprod_tail = prod(gs_tail)
         for j ∈ inds_first
             I = Is[j, js_tail...]


### PR DESCRIPTION
Deconvolution is the cheapest part of type-1 and type-2 NUFFTs (linear on the number of Fourier modes), and up to now it was not parallelised. But in some cases its cost can become relevant.

This PR adds threads-based parallelisation for the deconvolution operations. Moreover, for type-2 NUFFTs, filling the intermediate oversampled array with zeros is now faster by using `memset` in parallel over chunks of each array.