### PR TITLE
Fix roundoff errors when a point is near π

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NonuniformFFTs"
 uuid = "cd96f58b-6017-4a02-bb9e-f4d81626177f"
 authors = ["Juan Ignacio Polanco <juan-ignacio.polanco@cnrs.fr>"]
-version = "0.3.14"
+version = "0.3.15"
 
 [deps]
 Bessels = "0e736298-9ec6-45e8-9647-e4fc86a2fe38"

--- a/src/Kernels/Kernels.jl
+++ b/src/Kernels/Kernels.jl
@@ -72,11 +72,11 @@ end
 @inline function point_to_cell(x, Δx)
     r = x / Δx
     i = unsafe_trunc(Int, r)  # assumes r ≥ 0
-    # When x is very close to 2π, then doing (x / Δx) * Δx may actually be ≥ 2π due to
-    # roundoff errors. We account for this below.
-    L = 2 * oftype(x, π)  # = 2π
-    x_new = r * Δx
-    ifelse(x_new < L, i + 1, i)  # index such that xs[j] ≤ x₀ < xs[j + 1]
+    # Increment by 1 (for one-based indexing), except to avoid possible roundoff errors when x
+    # is very close (but slightly smaller) to i * Δx.
+    i += (i * Δx ≤ x)  # this is almost always true (so we increment by 1)
+    # @assert (i - 1) * Δx ≤ x < i * Δx
+    i
 end
 
 @inline function evaluate_kernel(g::AbstractKernelData, x₀)

--- a/src/spreading.jl
+++ b/src/spreading.jl
@@ -73,7 +73,7 @@ function spread_from_point_blocked!(
         is .+ δ  # shift to beginning of current block
     end
     Is = CartesianIndices(inds)
-    # Base.checkbounds.(us, Tuple(Is))  # check that indices fall inside the output array
+    # checkbounds.(us, Ref(Is))  # check that indices fall inside the output array
 
     vals = map(g -> g.values, gs_eval)
     spread_onto_arrays_blocked!(us, Is, vals, vs)

--- a/test/near_2pi.jl
+++ b/test/near_2pi.jl
@@ -1,10 +1,19 @@
 using Test
 using NonuniformFFTs
 using NonuniformFFTs: Kernels
-using FFTW: fftfreq
+using FFTW: fftfreq, rfftfreq
+
+function type1_exact!(us, ks, xp, vp)
+    fill!(us, 0)
+    for i ∈ eachindex(xp, vp)
+        for j ∈ eachindex(us)
+            us[j] += vp[i] * cis(-xp[i] * ks[j])
+        end
+    end
+    us
+end
 
 # Test that roundoff errors are properly accounted for when a point is very close to 2π.
-
 @testset "Point near 2π" begin
     L = 2π
 
@@ -22,13 +31,9 @@ using FFTW: fftfreq
         us = Array{T}(undef, N)
         exec_type1!(us, plan, vp)
 
-        us_exact = fill!(similar(us), 0)
+        us_exact = similar(us)
         ks = fftfreq(N, N)
-        for i ∈ eachindex(xp, vp)
-            for j ∈ eachindex(us_exact)
-                us_exact[j] += vp[i] * cis(-xp[i] * ks[j])
-            end
-        end
+        type1_exact!(us_exact, ks, xp, vp)
 
         @test isapprox(us, us_exact; rtol = 1e-11)
     end
@@ -45,4 +50,31 @@ using FFTW: fftfreq
             @test Kernels.point_to_cell(x, Δx) == 3
         end
     end
+end
+
+# Test similar issue when x = π - ε
+@testset "Point near π" begin
+    N = 16  # number of Fourier modes
+    T = Float64
+    x = T(π)
+    x = prevfloat(x)
+    xp = [x]
+    vp = [3.4]
+
+    @testset "Kernels.point_to_cell" begin
+        Δx = T(2π) / 24
+        i = Kernels.point_to_cell(x, Δx)
+        @test (i - 1) * Δx ≤ x < i * Δx
+    end
+
+    plan_nufft = PlanNUFFT(T, N; m = HalfSupport(4), σ = 1.5)
+    set_points!(plan_nufft, xp)
+    us = Array{Complex{T}}(undef, size(plan_nufft))
+    exec_type1!(us, plan_nufft, vp)
+
+    us_exact = similar(us)
+    ks = rfftfreq(N, N)
+    type1_exact!(us_exact, ks, xp, vp)
+
+    @test isapprox(us, us_exact; rtol = 1e-5)
 end


### PR DESCRIPTION
This fixes a round-off error when a non-uniform point is at $x = \pi - \varepsilon$, where $\varepsilon$ is basically the epsilon machine. This round-off error appeared  for certain grid sizes $\Delta x$.