### PR TITLE
GPU: implement spatial sorting of non-uniform points

### DIFF
--- a/src/NonuniformFFTs.jl
+++ b/src/NonuniformFFTs.jl
@@ -146,11 +146,7 @@ function exec_type1!(ûs_k::NTuple{C, AbstractArray{<:Complex}}, p::PlanNUFFT, 
         end
 
         @timeit timer "(1) Spreading" begin
-            if with_blocking(blocks)
-                spread_from_points_blocked!(backend, kernels, blocks, us, points, vp)  # CPU-only
-            else
-                spread_from_points!(backend, kernels, us, points, vp)  # single-threaded case? Also GPU case.
-            end
+            spread_from_points!(backend, blocks, kernels, us, points, vp)
             KA.synchronize(backend)
         end
 
@@ -249,11 +245,7 @@ function exec_type2!(vp::NTuple{C, AbstractVector}, p::PlanNUFFT, ûs_k::NTuple
         end
 
         @timeit timer "(3) Interpolation" begin
-            if with_blocking(blocks)
-                interpolate_blocked!(kernels, blocks, vp, us, points)  # CPU-onlu
-            else
-                interpolate!(backend, kernels, vp, us, points)  # single-threaded case? Also GPU case.
-            end
+            interpolate!(backend, blocks, kernels, vp, us, points)
             KA.synchronize(backend)
         end
     end

--- a/src/NonuniformFFTs.jl
+++ b/src/NonuniformFFTs.jl
@@ -55,13 +55,8 @@ function default_workgroupsize(backend, ndrange::Dims)
     KA.default_cpu_workgroupsize(ndrange)
 end
 
-# Reducing the number of threads to 64 for 1D GPU kernels seems to improve performance
-# (tested on Nvidia A100). 1D kernels are those iterating over non-uniform points, i.e.
-# spreading and interpolation, which usually dominate performance.
-# TODO: this seems to be only true when data is randomly located and sorting is not
-# performed. With sorting, it looks like larger workgroups are faster, so we should revert
-# this when sorting on GPU is implemented.
-default_workgroupsize(::GPU, ndrange::Dims{1}) = (min(64, ndrange[1]),)
+# Case of 1D kernels on the GPU (typically, kernels which iterate over non-uniform points).
+default_workgroupsize(::GPU, ndrange::Dims{1}) = (min(512, ndrange[1]),)
 
 include("sorting.jl")
 include("sorting_hilbert.jl")

--- a/src/NonuniformFFTs.jl
+++ b/src/NonuniformFFTs.jl
@@ -64,6 +64,7 @@ end
 default_workgroupsize(::GPU, ndrange::Dims{1}) = (min(64, ndrange[1]),)
 
 include("sorting.jl")
+include("sorting_hilbert.jl")
 include("blocking.jl")
 include("plan.jl")
 include("set_points.jl")

--- a/src/abstractNFFTs.jl
+++ b/src/abstractNFFTs.jl
@@ -91,7 +91,7 @@ Base.@constprop :aggressive function PlanNUFFT(
     m, σ, reltol = AbstractNFFTs.accuracyParams(; kwargs...)
     backend = KA.get_backend(xp)  # e.g. use GPU backend if xp is a GPU array
     sort_points = sortNodes ? True() : False()  # this is type-unstable (unless constant propagation happens)
-    block_size = blocking ? default_block_size() : nothing  # also type-unstable
+    block_size = blocking ? default_block_size(backend) : nothing  # also type-unstable
     kernel = window isa AbstractKernel ? window : convert_window_function(window)
     p = PlanNUFFT(Complex{Tr}, Ns, HalfSupport(m); backend, σ = Tr(σ), sort_points, fftshift, block_size, kernel, fftw_flags = fftflags)
     AbstractNFFTs.nodes!(p, xp)

--- a/src/blocking.jl
+++ b/src/blocking.jl
@@ -21,6 +21,7 @@ end
 # or anything else which has length `N`.
 function set_points!(backend, ::NullBlockData, points::StructVector, xp, timer; transform::F = identity) where {F <: Function}
     length(points) == length(xp) || resize_no_copy!(points, length(xp))
+    KA.synchronize(backend)
     Base.require_one_based_indexing(points)
     @timeit timer "(1) Copy + fold" begin
         # NOTE: we explicitly iterate through StructVector components because CUDA.jl

--- a/src/blocking.jl
+++ b/src/blocking.jl
@@ -15,16 +15,14 @@ end
 
 # Here the element type of `xp` can be either an NTuple{N, <:Real}, an SVector{N, <:Real},
 # or anything else which has length `N`.
-function set_points!(::NullBlockData, points::StructVector, xp, timer; transform::F = identity) where {F <: Function}
-    # TODO: avoid implicit copy in resize!? (can be costly, especially on GPU)
-    length(points) == length(xp) || resize!(points, length(xp))
+function set_points!(backend, ::NullBlockData, points::StructVector, xp, timer; transform::F = identity) where {F <: Function}
+    length(points) == length(xp) || resize_no_copy!(points, length(xp))
     Base.require_one_based_indexing(points)
     @timeit timer "(1) Copy + fold" begin
         # NOTE: we explicitly iterate through StructVector components because CUDA.jl
         # currently fails when implicitly writing to a StructArray (compilation fails,
         # tested on Julia 1.11-rc3 and CUDA.jl v5.4.3).
         points_comp = StructArrays.components(points)
-        backend = KA.get_backend(points_comp[1])
         kernel! = copy_points_unblocked_kernel!(backend)
         kernel!(transform, points_comp, xp; ndrange = size(xp))
         KA.synchronize(backend)  # mostly to get accurate timings
@@ -51,6 +49,205 @@ type_length(::Type{<:NTuple{N}}) where {N} = N
 
 # ================================================================================ #
 
+# Maximum number of bits allowed for Hilbert sort.
+# Hilbert sorting divides the domain in a grid of size N^d, where `d` is the dimension and
+# N = 2^b. Here `b` is the number of bits used in the algorithm.
+# This means that `b = 16` corresponds to a grid of dimensions 65536 *in each direction*,
+# which is far larger than anything we will ever need in practice.
+# (Also note that the Hilbert "grid" is generally coarser than the actual NUFFT grid where
+# values are spread and interpolated.)
+const MAX_BITS_HILBERT_SORT = 16
+
+# GPU implementation
+struct BlockDataGPU{
+        PermVector <: AbstractVector{<:Integer},
+        SortPoints <: StaticBool,
+    } <: AbstractBlockData
+    pointperm     :: PermVector
+    nbits_hilbert :: Int  # number of bits required in Hilbert sorting
+    sort_points   :: SortPoints
+
+    BlockDataGPU(pointperm::P, nbits, sort::S) where {P, S} =
+        new{P, S}(pointperm, nbits, sort)
+end
+
+with_blocking(::BlockDataGPU) = true
+
+# In the case of Hilbert sorting, what we call "block" corresponds to the size of the
+# minimal box in the Hilbert curve algorithm.
+function BlockDataGPU(backend::KA.Backend, block_dims::Dims{D}, Ñs::Dims{D}, sort_points) where {D}
+    # We use a Hilbert sorting algorithm which requires the same number of blocks in each
+    # direction. In the best case, blocks will have the size required by `block_dims`. If
+    # that's not possible, we will prefer to use a smaller block size (so more blocks).
+    # This makes sense if the input block size was tuned as proportional to some memory
+    # limit (e.g. shared memory size on GPUs).
+    nblocks_per_dir_wanted = map(Ñs, block_dims) do N, B
+        cld(N, B)  # ≥ 1
+    end
+    nblocks = max(nblocks_per_dir_wanted...)  # this makes the actual block size ≤ the wanted block size
+    nbits = exponent(nblocks - 1) + 1
+    @assert UInt(2)^(nbits - 1) < nblocks ≤ UInt(2)^nbits  # verify that we got the right value of nbits
+    nbits = min(nbits, MAX_BITS_HILBERT_SORT)  # just in case; in practice nbits < MAX_BITS_HILBERT_SORT all the time
+    pointperm = KA.allocate(backend, Int, 0)   # stores permutation indices
+    BlockDataGPU(pointperm, nbits, sort_points)
+end
+
+function set_points!(
+        backend::GPU, bd::BlockDataGPU, points::StructVector, xp, timer;
+        transform::F = identity,
+    ) where {F <: Function}
+
+    # Total number of bits required to hold a Hilbert index.
+    # The index type T must be larger than this size.
+    # nbits_index = N * nbits_hilbert
+
+    # Recursively iterate over possible values of nbits_hilbert to avoid type instability.
+    # We start by nbits = 1, and increase until nbits == bd.nbits_hilbert.
+    @assert bd.nbits_hilbert ≤ MAX_BITS_HILBERT_SORT
+    _set_points_hilbert!(Val(1), backend, bd, points, xp, timer, transform)
+
+    # if nbits_index ≤ 8 * sizeof(UInt8)
+    #     _set_points!(UInt8, backend, bd, points, xp, timer, transform)
+    # elseif nbits_index ≤ 8 * sizeof(UInt16)
+    #     _set_points!(UInt16, backend, bd, points, xp, timer, transform)
+    # elseif nbits_index ≤ 8 * sizeof(UInt32)
+    #     _set_points!(UInt32, backend, bd, points, xp, timer, transform)
+    # else
+    #     _set_points!(UInt64, backend, bd, points, xp, timer, transform)
+    # end
+
+    nothing
+end
+
+@inline function _set_points_hilbert!(::Val{nbits}, backend, bd, points, xp, args...) where {nbits}
+    if nbits > 16  # this is to avoid the compiler from exploding if it thinks the recursion is infinite
+        nothing
+    elseif nbits == bd.nbits_hilbert
+        N = type_length(eltype(xp))  # = number of dimensions
+        alg = GlobalGrayStatic(nbits, N)  # should be inferred, since nbits is statically known
+        _set_points_hilbert!(alg, backend, bd, points, xp, args...)  # call method defined further below
+    else
+        _set_points_hilbert!(Val(nbits + 1), backend, bd, points, xp, args...)  # keep iterating
+    end
+end
+
+function _set_points_hilbert!(
+        sortalg::HilbertSortingAlgorithm, backend, bd::BlockDataGPU,
+        points::StructVector, xp, timer, transform::F,
+    ) where {F}
+    (; pointperm, sort_points,) = bd
+
+    B = nbits(sortalg)  # static value
+    nblocks = 1 << B    # same number of blocks in all directions (= 2^B)
+
+    Np = length(xp)
+    resize_no_copy!(pointperm, Np)
+    resize_no_copy!(points, Np)
+    @assert eachindex(points) == eachindex(xp)
+
+    # Allocate temporary array for holding Hilbert indices (manually deallocated later)
+    T = eltype(sortalg)
+    inds = KA.zeros(backend, T, Np)
+
+    # We avoid passing a StructVector to the kernel, so we pass `points` as a tuple of
+    # vectors. The kernel might fail if `xp` is also a StructVector, which is not imposed
+    # nor disallowed.
+    points_comp = StructArrays.components(points)
+
+    ndrange = size(points)
+    groupsize = default_workgroupsize(backend, ndrange)
+    kernel! = hilbert_sort_kernel!(backend, groupsize, ndrange)
+    @timeit timer "(1) Hilbert encoding" begin
+        kernel!(inds, points_comp, xp, sortalg, nblocks, sort_points, transform)
+        KA.synchronize(backend)
+    end
+
+    # Compute permutation needed to sort Hilbert indices.
+    @timeit timer "(2) Sortperm" begin
+        sortperm!(pointperm, inds)
+        KA.synchronize(backend)
+    end
+    KA.unsafe_free!(inds)
+
+    # `pointperm` now contains the permutation needed to sort points
+    if sort_points === True()
+        @timeit timer "(3) Permute points" let
+            local kernel! = permute_kernel!(backend, groupsize, ndrange)
+            kernel!(points_comp, xp, pointperm, transform)
+            KA.synchronize(backend)
+            resize!(pointperm, 0)  # free some memory (we won't need it anymore)
+        end
+    end
+
+    nothing
+end
+
+# This kernel may do multiple things at once:
+# - Compute Hilbert index associated to a point
+# - Copy point from `xp` to `points`, after transformations and folding, if sort_points === False().
+@kernel function hilbert_sort_kernel!(
+        inds::AbstractVector{<:Unsigned},
+        points::NTuple,
+        @Const(xp),
+        @Const(sortalg::HilbertSortingAlgorithm),
+        @Const(nblocks::Integer),  # TODO: can we pass this as a compile-time constant? (Val)
+        @Const(sort_points),
+        @Const(transform::F),
+    ) where {F}
+    I = @index(Global, Linear)
+    @inbounds x⃗ = xp[I]
+    y⃗ = to_unit_cell(transform(Tuple(x⃗))) :: NTuple
+    T = eltype(y⃗)
+    @assert T <: AbstractFloat
+
+    L = T(2) * π
+    block_size = L / nblocks
+
+    is = map(y⃗) do y
+        i = Kernels.point_to_cell(y, block_size)
+        i - one(i)  # Hilbert sorting requires zero-based indices
+    end
+
+    @inbounds inds[I] = encode_hilbert_zero(sortalg, is)  # compute Hilbert index for sorting
+
+    # If points need to be sorted, then we fill `points` some time later (in permute_kernel!).
+    if sort_points === False()
+        for n ∈ eachindex(x⃗)
+            @inbounds points[n][I] = y⃗[n]
+        end
+    end
+
+    nothing
+end
+
+@kernel function permute_kernel!(
+        points::NTuple,
+        @Const(xp::AbstractVector),
+        @Const(perm::AbstractVector{<:Integer}),
+        @Const(transform::F),
+    ) where {F}
+    i = @index(Global, Linear)
+    j = @inbounds perm[i]
+    x⃗ = @inbounds xp[j]
+    y⃗ = to_unit_cell(transform(Tuple(x⃗))) :: NTuple  # note: we perform the transform + folding twice per point...
+    for n ∈ eachindex(x⃗)
+        @inbounds points[n][i] = y⃗[n]
+    end
+    nothing
+end
+
+# Resize vector trying to avoid copy when N is larger than the original length.
+# In other words, we completely discard the original contents of x, which is not the
+# original behaviour of resize!. This can save us some device-to-device copies.
+function resize_no_copy!(x, N)
+    resize!(x, 0)
+    resize!(x, N)
+    x
+end
+
+# ================================================================================ #
+
+# CPU only
 struct BlockData{
         T, N, Nc,
         Tr,  # = real(T)
@@ -82,7 +279,7 @@ function BlockData(
         @assert N - M > 0
         min(B, N ÷ 2, N - M)
     end
-    dims = block_dims .+ 2M  # include padding for values outside of block
+    dims = block_dims .+ 2M  # include padding for values outside of block (TODO: include padding in original block_dims?)
     Tr = real(T)
     block_sizes = map(Ñs, block_dims) do N, B
         @inline
@@ -108,11 +305,9 @@ function BlockData(
     )
 end
 
-# Blocking is considered to be disabled if there are no allocated buffers.
-with_blocking(bd::BlockData) = !isempty(bd.buffers)
-
-function set_points!(bd::BlockData, points::StructVector, xp, timer; transform::F = identity) where {F <: Function}
-    with_blocking(bd) || return set_points!(NullBlockData(), points, xp, timer)
+function set_points!(::CPU, bd::BlockData, points::StructVector, xp, timer; transform::F = identity) where {F <: Function}
+    # This technically never happens, but we might use it as a way to disable blocking.
+    isempty(bd.buffers) && return set_points!(NullBlockData(), points, xp, timer)
 
     (; indices, cumulative_npoints_per_block, blockidx, pointperm, block_sizes,) = bd
     N = type_length(eltype(xp))  # = number of dimensions
@@ -120,9 +315,9 @@ function set_points!(bd::BlockData, points::StructVector, xp, timer; transform::
     fill!(cumulative_npoints_per_block, 0)
     to_linear_index = LinearIndices(axes(indices))  # maps Cartesian to linear index of a block
     Np = length(xp)
-    resize!(blockidx, Np)
-    resize!(pointperm, Np)
-    resize!(points, Np)
+    resize_no_copy!(blockidx, Np)
+    resize_no_copy!(pointperm, Np)
+    resize_no_copy!(points, Np)
 
     @timeit timer "(1) Assign blocks" @inbounds for (i, x⃗) ∈ pairs(xp)
         # Get index of block where point x⃗ is located.

--- a/src/blocking.jl
+++ b/src/blocking.jl
@@ -273,7 +273,7 @@ function BlockData(
         @assert N - M > 0
         min(B, N ÷ 2, N - M)
     end
-    dims = block_dims .+ 2M  # include padding for values outside of block (TODO: include padding in original block_dims?)
+    dims = block_dims .+ 2M  # include padding for values outside of block (TODO: include padding in original block_dims? requires minimal block_size in each direction)
     Tr = real(T)
     block_sizes = map(Ñs, block_dims) do N, B
         @inline
@@ -299,9 +299,9 @@ function BlockData(
     )
 end
 
-function set_points!(::CPU, bd::BlockData, points::StructVector, xp, timer; transform::F = identity) where {F <: Function}
+function set_points!(backend::CPU, bd::BlockData, points::StructVector, xp, timer; transform::F = identity) where {F <: Function}
     # This technically never happens, but we might use it as a way to disable blocking.
-    isempty(bd.buffers) && return set_points!(NullBlockData(), points, xp, timer)
+    isempty(bd.buffers) && return set_points!(backend, NullBlockData(), points, xp, timer; transform)
 
     (; indices, cumulative_npoints_per_block, blockidx, pointperm, block_sizes,) = bd
     N = type_length(eltype(xp))  # = number of dimensions

--- a/src/interpolation/cpu_blocked.jl
+++ b/src/interpolation/cpu_blocked.jl
@@ -89,9 +89,10 @@ function interpolate_from_arrays_blocked(
     end
 end
 
-function interpolate_blocked!(
-        gs,
+function interpolate!(
+        backend::CPU,
         bd::BlockData,
+        gs,
         vp_all::NTuple{C, AbstractVector},
         us::NTuple{C, AbstractArray},
         x⃗s::AbstractArray,

--- a/src/interpolation/cpu_nonblocked.jl
+++ b/src/interpolation/cpu_nonblocked.jl
@@ -1,5 +1,6 @@
 function interpolate!(
         backend::CPU,
+        ::NullBlockData,
         gs,
         vp_all::NTuple{C, AbstractVector},
         us::NTuple{C, AbstractArray},

--- a/src/interpolation/gpu.jl
+++ b/src/interpolation/gpu.jl
@@ -78,15 +78,16 @@ function interpolate!(
         pointperm_ = pointperm
     end
 
-    # TODO: use dynamically sized kernel? (to avoid recompilation, since number of points may change from one call to another)
+    # We use dynamically sized kernels to avoid recompilation, since number of points may
+    # change from one call to another.
     ndrange = size(x⃗s)  # iterate through points
     workgroupsize = default_workgroupsize(backend, ndrange)
-    kernel! = interpolate_to_point_naive_kernel!(backend, workgroupsize, ndrange)
-    kernel!(vp_sorted, xs_comp, us, pointperm_, Δxs, evaluate, to_indices)
+    kernel! = interpolate_to_point_naive_kernel!(backend)
+    kernel!(vp_sorted, xs_comp, us, pointperm_, Δxs, evaluate, to_indices; workgroupsize, ndrange)
 
     if sort_points === True()
-        kernel_perm! = interp_permute_kernel!(backend, workgroupsize, ndrange)
-        kernel_perm!(vp_all, vp_sorted, pointperm)
+        kernel_perm! = interp_permute_kernel!(backend)
+        kernel_perm!(vp_all, vp_sorted, pointperm; workgroupsize, ndrange)
         foreach(KA.unsafe_free!, vp_sorted)  # manually deallocate temporary arrays
     end
 

--- a/src/interpolation/gpu.jl
+++ b/src/interpolation/gpu.jl
@@ -6,7 +6,6 @@ using StaticArrays: MVector
         @Const(points::NTuple{D}),
         @Const(us::NTuple{C}),
         @Const(pointperm),
-        @Const(sort_points::StaticBool),
         @Const(Δxs::NTuple{D}),           # grid step in each direction (oversampled grid)
         evaluate::NTuple{D, <:Function},  # can't be marked Const for some reason
         to_indices::NTuple{D, <:Function},
@@ -19,13 +18,7 @@ using StaticArrays: MVector
         @inbounds pointperm[i]
     end
 
-    i_x = if sort_points === True()
-        i  # points have already been sorted, so we access them contiguously (should be faster, once the permutation has been done)
-    else
-        j  # don't access points contiguously in memory, but interpolate in a localised region in space (and GPU memory?)
-    end
-
-    x⃗ = map(xs -> @inbounds(xs[i_x]), points)
+    x⃗ = map(xs -> @inbounds(xs[j]), points)
 
     # Determine grid dimensions.
     # Unlike in spreading, here `us` can be made of arrays of complex numbers, because we
@@ -44,7 +37,6 @@ using StaticArrays: MVector
         geval.values .* Δx
     end
 
-    # v⃗ = @inline interpolate_from_arrays(us, inds, vals)
     v⃗ = interpolate_from_arrays_gpu(us, inds, vals)
 
     for (dst, v) ∈ zip(vp, v⃗)
@@ -78,11 +70,25 @@ function interpolate!(
         @assert eachindex(pointperm) == eachindex(x⃗s)
     end
 
+    if sort_points === True()
+        vp_sorted = map(similar, vp_all)  # allocate temporary arrays for sorted non-uniform data
+        pointperm_ = nothing  # we don't need permutations in interpolation kernel (all accesses to non-uniform data will be contiguous)
+    else
+        vp_sorted = vp_all
+        pointperm_ = pointperm
+    end
+
     # TODO: use dynamically sized kernel? (to avoid recompilation, since number of points may change from one call to another)
     ndrange = size(x⃗s)  # iterate through points
     workgroupsize = default_workgroupsize(backend, ndrange)
     kernel! = interpolate_to_point_naive_kernel!(backend, workgroupsize, ndrange)
-    kernel!(vp_all, xs_comp, us, pointperm, sort_points, Δxs, evaluate, to_indices)
+    kernel!(vp_sorted, xs_comp, us, pointperm_, Δxs, evaluate, to_indices)
+
+    if sort_points === True()
+        kernel_perm! = interp_permute_kernel!(backend, workgroupsize, ndrange)
+        kernel_perm!(vp_all, vp_sorted, pointperm)
+        foreach(KA.unsafe_free!, vp_sorted)  # manually deallocate temporary arrays
+    end
 
     vp_all
 end
@@ -138,4 +144,14 @@ end
         end
         Tuple(vs)
     end
+end
+
+# This applies the *inverse* permutation by switching i ↔ j indices (opposite of spread_permute_kernel!).
+@kernel function interp_permute_kernel!(vp::NTuple{N}, @Const(vp_in::NTuple{N}), @Const(perm::AbstractVector)) where {N}
+    i = @index(Global, Linear)
+    j = @inbounds perm[i]
+    for n ∈ 1:N
+        @inbounds vp[n][j] = vp_in[n][i]
+    end
+    nothing
 end

--- a/src/interpolation/gpu.jl
+++ b/src/interpolation/gpu.jl
@@ -41,6 +41,7 @@ end
 
 function interpolate!(
         backend::GPU,
+        bd::Union{BlockDataGPU, NullBlockData},
         gs,
         vp_all::NTuple{C, AbstractVector},
         us::NTuple{C, AbstractArray},

--- a/src/interpolation/gpu.jl
+++ b/src/interpolation/gpu.jl
@@ -5,12 +5,27 @@ using StaticArrays: MVector
         vp::NTuple{C},
         @Const(points::NTuple{D}),
         @Const(us::NTuple{C}),
+        @Const(pointperm),
+        @Const(sort_points::StaticBool),
         @Const(Δxs::NTuple{D}),           # grid step in each direction (oversampled grid)
         evaluate::NTuple{D, <:Function},  # can't be marked Const for some reason
         to_indices::NTuple{D, <:Function},
     ) where {C, D}
     i = @index(Global, Linear)
-    x⃗ = map(xs -> @inbounds(xs[i]), points)
+
+    j = if pointperm === nothing
+        i
+    else
+        @inbounds pointperm[i]
+    end
+
+    i_x = if sort_points === True()
+        i  # points have already been sorted, so we access them contiguously (should be faster, once the permutation has been done)
+    else
+        j  # don't access points contiguously in memory, but interpolate in a localised region in space (and GPU memory?)
+    end
+
+    x⃗ = map(xs -> @inbounds(xs[i_x]), points)
 
     # Determine grid dimensions.
     # Unlike in spreading, here `us` can be made of arrays of complex numbers, because we
@@ -33,7 +48,7 @@ using StaticArrays: MVector
     v⃗ = interpolate_from_arrays_gpu(us, inds, vals)
 
     for (dst, v) ∈ zip(vp, v⃗)
-        @inbounds dst[i] = v
+        @inbounds dst[j] = v
     end
 
     nothing
@@ -56,11 +71,18 @@ function interpolate!(
     xs_comp = StructArrays.components(x⃗s)
     Δxs = map(Kernels.gridstep, gs)
 
+    pointperm = get_pointperm(bd)                  # nothing in case of NullBlockData
+    sort_points = get_sort_points(bd)::StaticBool  # False in the case of NullBlockData
+
+    if pointperm !== nothing
+        @assert eachindex(pointperm) == eachindex(x⃗s)
+    end
+
     # TODO: use dynamically sized kernel? (to avoid recompilation, since number of points may change from one call to another)
     ndrange = size(x⃗s)  # iterate through points
     workgroupsize = default_workgroupsize(backend, ndrange)
     kernel! = interpolate_to_point_naive_kernel!(backend, workgroupsize, ndrange)
-    kernel!(vp_all, xs_comp, us, Δxs, evaluate, to_indices)
+    kernel!(vp_all, xs_comp, us, pointperm, sort_points, Δxs, evaluate, to_indices)
 
     vp_all
 end

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -92,11 +92,14 @@ The created plan contains all data needed to perform NUFFTs for non-uniform data
   or when sorting is enabled.
   This can be tuned for maximal performance.
   Using block partitioning is required for running with multiple threads.
-  Blocking can be completely disabled by passing `block_size = nothing` (but this is
-  generally slower, even when running on a single thread).
+  On the GPU, this will perform spatial sorting using a Hilbert curve algorithm, whose
+  minimal scale is proportional to the value of `block_size`.
+  Blocking / spatial sorting can be completely disabled by passing `block_size = nothing` (but this is
+  generally slower).
 
 - `sort_points = False()`: whether to internally permute the order of the non-uniform points.
   This can be enabled by passing `sort_points = True()`.
+  Ignored when `block_size = nothing` (which disables spatial sorting).
   In this case, more time will be spent in [`set_points!`](@ref) and less time on the actual transforms.
   This can improve performance if executing multiple transforms on the same non-uniform points.
   Note that, even when enabled, this does not modify the `points` argument passed to `set_points!`.

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -88,10 +88,12 @@ The created plan contains all data needed to perform NUFFTs for non-uniform data
 
 ## Performance parameters
 
-- `block_size = 4096`: the linear block size (in number of elements) when using block partitioning
+- `block_size::Int`: the linear block size (in number of elements) when using block partitioning
   or when sorting is enabled.
   This can be tuned for maximal performance.
-  Using block partitioning is required for running with multiple threads.
+  The current defaults are 4096 (CPU) and 1024 (GPU), but these may change in the future or
+  even depend on the actual computing device.
+  On the CPU, using block partitioning is required for running with multiple threads.
   On the GPU, this will perform spatial sorting using a Hilbert curve algorithm, whose
   minimal scale is proportional to the value of `block_size`.
   Blocking / spatial sorting can be completely disabled by passing `block_size = nothing` (but this is
@@ -253,7 +255,7 @@ ntransforms(::PlanNUFFT{T, N, Nc}) where {T, N, Nc} = Nc
 default_block_size(::CPU) = 4096  # in number of linear elements
 
 # TODO: adapt this based on size of shared memory and on element type T (and padding 2M)?
-default_block_size(::GPU) = 4096
+default_block_size(::GPU) = 1024  # a bit faster than 4096 on A100 (with 256³ oversampled grid)
 
 function get_block_dims(Ñs::Dims, bsize::Int)
     d = length(Ñs)

--- a/src/set_points.jl
+++ b/src/set_points.jl
@@ -32,7 +32,7 @@ function set_points!(p::PlanNUFFT, xp::AbstractVector; kwargs...)
     (; points, timer,) = p
     N = ndims(p)
     type_length(eltype(xp)) == N || throw(DimensionMismatch(lazy"expected $N-dimensional points"))
-    @timeit timer "Set points" set_points!(p.blocks, points, xp, timer; kwargs...)
+    @timeit timer "Set points" set_points!(p.backend, p.blocks, points, xp, timer; kwargs...)
     p
 end
 

--- a/src/sorting_hilbert.jl
+++ b/src/sorting_hilbert.jl
@@ -1,0 +1,135 @@
+# Code adapted from the BijectiveHilbert.jl package by Andrew Dolgert (MIT license).
+#
+# Hilbert sorting is a method for sorting a set of points in n-dimensional space so that
+# points which are physically close are also close in memory. See for instance:
+#
+# - https://en.wikipedia.org/wiki/Hilbert_curve
+# - https://charlesreid1.com/wiki/Hilbert_Sort
+# - https://doc.cgal.org/latest/Spatial_sorting/index.html
+# - https://computingkitchen.com/BijectiveHilbert.jl/stable/hilbert/
+#
+# We define a GlobalGrayStatic{T,B} type adapted from the BijectiveHilbert.GlobalGray{T}
+# type. The differences are that GlobalGrayStatic contains the number of bits `B` as a
+# static parameter, and that it simply does not include the number
+# of dimensions `n`. Instead, `n` is inferred from the input to `encode_hilbert_zero`, which
+# should be a (statically-sized) `Tuple` instead of a `Vector` as in BijectiveHilbert.jl.
+#
+# Moreover, functions for computing the Hilbert index have been adapted for working with
+# tuples and have no allocations. The performance is greatly improved compared to the
+# original GlobalGray type. Our code can also be called from GPU kernels, since it only uses
+# tuples and MVectors.
+#
+# We only implement encoding as we currently don't need decoding.
+#
+# See also https://computingkitchen.com/BijectiveHilbert.jl/stable/globalgray/#Global-Gray
+# for some details on the algorithm.
+
+"""
+    GlobalGrayStatic(T <: Unsigned, B::Int)
+    GlobalGrayStatic(B::Int, N::Int)
+
+Hilbert sorting algorithm adapted from the `GlobalGray` algorithm in BijectiveHilbert.jl.
+
+Here `T <: Unsigned` is the type of the Hilbert index and `B` is the required number of
+bits per dimension. For `B` bits, the algorithm creates a grid of size ``2^B`` in each
+direction.
+
+The second constructor chooses the smallest unsigned type `T` based on the required number
+of bits `B` and the space dimension `N`. If they are constants, they will likely be
+constant-propagated so that `T` is inferred by the compiler.
+
+The total number of bits required is `nbits = B * N`. For instance, if `N = 3` and `B = 4`
+(corresponding to a grid of dimensions ``(2^4)^3 = 16^3``), then `nbits = 12` and the
+smallest possible type `T` is `UInt16`, whose size is `8 * sizeof(UInt16) = 16` bits (as its
+name suggests!).
+"""
+struct GlobalGrayStatic{T, B} end
+
+Base.eltype(::GlobalGrayStatic{T}) where {T} = T
+
+GlobalGrayStatic(::Type{T}, B::Int) where {T} = GlobalGrayStatic{T, B}()
+
+Base.@constprop :aggressive function GlobalGrayStatic(B::Int, N::Int)
+    nbits = B * N  # minimal number of bits needed
+    T = large_enough_unsigned_static(Val(nbits))
+    GlobalGrayStatic{T, B}()
+end
+
+@inline function large_enough_unsigned_static(::Val{nbits}) where {nbits}
+    if @generated
+        unsigned_types = (UInt8, UInt16, UInt32, UInt64, UInt128)
+        for T ∈ unsigned_types
+            if 8 * sizeof(T) ≥ nbits
+                return :($T)
+            end
+        end
+        :(nothing)
+    else
+        unsigned_types = (UInt8, UInt16, UInt32, UInt64, UInt128)
+        for T ∈ unsigned_types
+            if 8 * sizeof(T) ≥ nbits
+                return T
+            end
+        end
+        nothing
+    end
+end
+
+"""
+    encode_hilbert_zero(algorithm::GlobalGrayStatic{T}, X::NTuple{N, <:Integer}) -> T
+
+Return Hilbert index associated to location `X` in `N`-dimensional space.
+"""
+function encode_hilbert_zero(::GlobalGrayStatic{T, B}, X::NTuple) where {T, B}
+    X = axes_to_transpose(X, Val(B))
+    interleave_transpose(T, X, Val(B))::T
+end
+
+function axes_to_transpose(X_in::NTuple{N,T}, ::Val{b}) where {N, b, T <: Integer}
+    X = MVector(X_in)
+    M = one(T) << (b - 1)
+    # Inverse undo
+    Q = M
+    @inbounds while Q > one(T)
+        P = Q - one(T)
+        for io ∈ 1:N
+            if !iszero(X[io] & Q)
+                X[1] ⊻= P
+            else
+                t = (X[1] ⊻ X[io]) & P
+                X[1] ⊻= t
+                X[io] ⊻= t
+            end
+        end
+        Q >>= one(Q)
+    end
+    # Gray encode
+    for jo ∈ 2:N
+        @inbounds X[jo] ⊻= X[jo - 1]
+    end
+    t2 = zero(T)
+    Q = M
+    @inbounds while Q > one(T)
+        if !iszero(X[N] & Q)
+            t2 ⊻= (Q - one(T))
+        end
+        Q >>= one(T)
+    end
+    for ko ∈ eachindex(X)
+        @inbounds X[ko] ⊻= t2
+    end
+    Tuple(X)
+end
+
+function interleave_transpose(::Type{T}, x::NTuple, ::Val{b}) where {T, b}
+    N = length(x)
+    S = eltype(x)
+    h = zero(T)
+    @inbounds for i ∈ 0:(b - 1)
+        for d ∈ eachindex(x)
+            ith_bit = Bool((x[d] & (one(S) << i)) >> i)  # 0 or 1
+            h |= T(ith_bit << (i * N + N - d))
+        end
+    end
+    h
+end

--- a/src/sorting_hilbert.jl
+++ b/src/sorting_hilbert.jl
@@ -24,8 +24,13 @@
 # See also https://computingkitchen.com/BijectiveHilbert.jl/stable/globalgray/#Global-Gray
 # for some details on the algorithm.
 
+abstract type HilbertSortingAlgorithm{T, B} end
+
+Base.eltype(::HilbertSortingAlgorithm{T}) where {T} = T
+nbits(::HilbertSortingAlgorithm{T, B}) where {T, B} = B
+
 """
-    GlobalGrayStatic(T <: Unsigned, B::Int)
+    GlobalGrayStatic(T <: Unsigned, B::Int) <: HilbertSortingAlgorithm{T, B}
     GlobalGrayStatic(B::Int, N::Int)
 
 Hilbert sorting algorithm adapted from the `GlobalGray` algorithm in BijectiveHilbert.jl.
@@ -43,9 +48,7 @@ The total number of bits required is `nbits = B * N`. For instance, if `N = 3` a
 smallest possible type `T` is `UInt16`, whose size is `8 * sizeof(UInt16) = 16` bits (as its
 name suggests!).
 """
-struct GlobalGrayStatic{T, B} end
-
-Base.eltype(::GlobalGrayStatic{T}) where {T} = T
+struct GlobalGrayStatic{T, B} <: HilbertSortingAlgorithm{T, B} end
 
 GlobalGrayStatic(::Type{T}, B::Int) where {T} = GlobalGrayStatic{T, B}()
 
@@ -79,6 +82,8 @@ end
     encode_hilbert_zero(algorithm::GlobalGrayStatic{T}, X::NTuple{N, <:Integer}) -> T
 
 Return Hilbert index associated to location `X` in `N`-dimensional space.
+
+Values in `X` usually correspond to indices on a grid. This function takes indices which start at 0 (!!).
 """
 function encode_hilbert_zero(::GlobalGrayStatic{T, B}, X::NTuple) where {T, B}
     X = axes_to_transpose(X, Val(B))

--- a/src/spreading/cpu_blocked.jl
+++ b/src/spreading/cpu_blocked.jl
@@ -80,10 +80,10 @@ function fill_with_zeros_serial!(us_all::NTuple{C, A}) where {C, A <: DenseArray
     us_all
 end
 
-function spread_from_points_blocked!(
+function spread_from_points!(
         ::CPU,
-        gs,
         bd::BlockData,
+        gs,
         us_all::NTuple{C, AbstractArray},
         xp::AbstractVector,
         vp_all::NTuple{C, AbstractVector},

--- a/src/spreading/cpu_nonblocked.jl
+++ b/src/spreading/cpu_nonblocked.jl
@@ -39,6 +39,7 @@ end
 
 function spread_from_points!(
         ::CPU,
+        ::NullBlockData,  # no blocking
         gs,
         us_all::NTuple{C, AbstractArray},
         x⃗s::AbstractVector,

--- a/src/spreading/gpu.jl
+++ b/src/spreading/gpu.jl
@@ -109,6 +109,7 @@ end
 # We assume all arrays are already on the GPU.
 function spread_from_points!(
         backend::GPU,
+        bd::Union{BlockDataGPU, NullBlockData},
         gs,
         us_all::NTuple{C, AbstractGPUArray},
         x⃗s::StructVector,

--- a/src/spreading/gpu.jl
+++ b/src/spreading/gpu.jl
@@ -150,23 +150,23 @@ function spread_from_points!(
         @assert eachindex(pointperm) == eachindex(x⃗s)
     end
 
-    # TODO: use dynamically sized kernel? (to avoid recompilation, since number of points
-    # may change from one call to another)
+    # We use dynamically sized kernels to avoid recompilation, since number of points may
+    # change from one call to another.
     ndrange = size(x⃗s)  # iterate through points
     workgroupsize = default_workgroupsize(backend, ndrange)
 
     if sort_points === True()
         vp_sorted = map(similar, vp_all)  # allocate temporary arrays for sorted non-uniform data
-        kernel_perm! = spread_permute_kernel!(backend, workgroupsize, ndrange)
-        kernel_perm!(vp_sorted, vp_all, pointperm)
+        kernel_perm! = spread_permute_kernel!(backend)
+        kernel_perm!(vp_sorted, vp_all, pointperm; workgroupsize, ndrange)
         pointperm_ = nothing  # we don't need any further permutations (all accesses to non-uniform data will be contiguous)
     else
         vp_sorted = vp_all
         pointperm_ = pointperm
     end
 
-    kernel! = spread_from_point_naive_kernel!(backend, workgroupsize, ndrange)
-    kernel!(us_real, xs_comp, vp_sorted, pointperm_, evaluate, to_indices)
+    kernel! = spread_from_point_naive_kernel!(backend)
+    kernel!(us_real, xs_comp, vp_sorted, pointperm_, evaluate, to_indices; workgroupsize, ndrange)
 
     if sort_points === True()
         foreach(KA.unsafe_free!, vp_sorted)  # manually deallocate temporary arrays

--- a/test/accuracy.jl
+++ b/test/accuracy.jl
@@ -95,7 +95,7 @@ function test_nufft_type1_1d(
         Np = 2 * N,
         m = HalfSupport(8),
         σ = 1.25,
-        block_size = NonuniformFFTs.default_block_size(),
+        block_size = NonuniformFFTs.default_block_size(CPU()),
     ) where {T <: Number}
     if T <: Real
         Tr = T
@@ -154,7 +154,7 @@ function test_nufft_type2_1d(
         Np = 2 * N,
         m = HalfSupport(8),
         σ = 1.25,
-        block_size = NonuniformFFTs.default_block_size(),
+        block_size = NonuniformFFTs.default_block_size(CPU()),
     ) where {T <: Number}
     if T <: Real
         Tr = T

--- a/test/multidimensional.jl
+++ b/test/multidimensional.jl
@@ -32,7 +32,7 @@ function test_nufft_type1(
         Np = 2 * first(Ns),
         m = HalfSupport(8),
         σ = 1.25,
-        block_size = NonuniformFFTs.default_block_size(),
+        block_size = NonuniformFFTs.default_block_size(CPU()),
         sort_points = False(),
     ) where {T <: Number}
     Tr = real(T)
@@ -79,7 +79,7 @@ function test_nufft_type2(
         Np = 2 * first(Ns),
         m = HalfSupport(8),
         σ = 1.25,
-        block_size = NonuniformFFTs.default_block_size(),
+        block_size = NonuniformFFTs.default_block_size(CPU()),
         sort_points = False(),
     ) where {T <: Number}
     Tr = real(T)


### PR DESCRIPTION
We use Hilbert sorting to ensure that spreading and interpolation operations are mostly localised in "physical" space and memory (except for periodic wrapping, which is non-local and should be fixed using ghost cells / padding).

This gives a near 3x performance improvement using random points with uniform distribution. And we're currently about 1.5x slower than CuFINUFFT on `ComplexF64` data when including `set_points!` time (tested on an Nvidia A100, with a $(2 \times 256)^3$ oversampled grid and $256^3$ random points).

Some raw test code (could be cleaned up...), with timings in comments:

```julia
using NonuniformFFTs
using Adapt
using CUDA
using FFTW
using LinearAlgebra: norm
using KernelAbstractions
using ThreadPinning
using Random: randn!, Xoshiro
using StaticArrays: SVector
using BenchmarkTools

pinthreads(:affinitymask)

# Note: this currently doesn't work with CUDA (due to the RNG), so it must be done with CPU arrays.
function random_points!(rng, xp::AbstractVector{<:SVector})
    # All types (V, T, N) need to be *inside* of the do-block for things to work with CUDA.
    map!(xp, xp) do x
        V = typeof(x)
        T = eltype(V)
        T(2π) * rand(rng, V)
    end
end

function to_block(x::Real, nblocks, L::Real)
    y = nblocks * x / L
    unsafe_trunc(Int, y) + 1
end

function to_block(x::SVector, nblocks::Dims, L)
    is = map((x, N) -> to_block(x, N, L), x, nblocks)
    @inbounds LinearIndices(nblocks)[is...]
end

function to_indices(x::SVector, nblocks::Int, L)
    map(x -> to_block(x, nblocks, L), x)
end

# We include a few sorting functions to try out the case where the input data is spatially
# sorted (artificially). If that helps with performance, then it makes sense to implement
# sorting in the code.
function sort_points_by_block(xp::AbstractVector{SVector{N,T}}, nblocks::Dims{N}) where {N, T <: AbstractFloat}
    # Assume points are in [0, 2π)ᵈ. Otherwise things may fail!
    L = T(2π)
    blocks = map(x -> Int32(to_block(x, nblocks, L)), xp)
    p = sortperm(blocks)
    xp[p]
end

function sort_points_naive(xp)
    p = sortperm(xp)
    xp[p]
end

function _sort_hilbert!(alg, inds, xp::AbstractVector{SVector{N,T}}; nblocks) where {N,T}
    L = T(2π)
    @inbounds for n ∈ eachindex(inds, xp)
        is = to_indices(xp[n], nblocks, L) .- 1
        inds[n] = NonuniformFFTs.encode_hilbert_zero(alg, Tuple(is))
    end
    inds
end

function sort_points_by_hilbert_index(xp::AbstractVector{SVector{N,T}}, nblocks::Integer; subsort = false) where {N, T <: AbstractFloat}
    # Assume points are in [0, 2π)ᵈ. Otherwise things may fail!
    bits = exponent(nblocks)  # 2^{bits} ≥ nblocks
    K = UInt32
    inds = similar(xp, K)
    alg = NonuniformFFTs.GlobalGrayStatic(K, bits)  # type unstable! (but we use a function barrier)
    _sort_hilbert!(alg, inds, xp; nblocks)  # function barrier
    p = sortperm(inds)
    xp_sorted = xp[p]

    subsort || return xp_sorted

    # For simplicity, sort indices as well.
    # This is really not optimised...
    inds = inds[p]
    # @assert issorted(inds)

    # Block limits
    lims = Int[]
    sizehint!(lims, nblocks^N)

    h_current = first(inds)
    @inbounds for i ∈ eachindex(inds)
        h = inds[i]
        if h != h_current
            @assert h > h_current
            push!(lims, i)
            h_current = h
        end
    end
    push!(lims, lastindex(inds) + 1)

    # Now sort within each block
    a = firstindex(lims)
    @time @inbounds for b ∈ lims
        # Sort points a:(b - 1), corresponding to a single block
        is = a:(b - 1)
        # @assert allequal(i -> inds[i], is)
        xp_i = view(xp_sorted, is)
        sort!(xp_i)
        a = b
    end

    xp_sorted
end

##

backend = CUDABackend()
# backend = CPU()

Ns = (256, 256, 256)  # number of Fourier modes in each direction
Np = prod(Ns)    # number of non-uniform points

# Generate some non-uniform random data
T = Complex{Float64}  # could also be e.g. Float64 for real non-uniform data
Tr = real(T)
D = length(Ns)                   # number of dimensions
rng = Xoshiro(42)
xp_init = allocate(CPU(), SVector{D, Tr}, Np)
random_points!(rng, xp_init)
# xp_init = sort_points_by_hilbert_index(xp_init, 64; subsort = false)
xp = adapt(backend, xp_init)  # copy to GPU if needed

xp_tup = ntuple(i -> getindex.(xp, i), D)  # layout needed by CuFINUFFT

vp_init = similar(xp_init, T)
randn!(rng, vp_init)  # random values at points
vp = adapt(backend, vp_init)

##

# Create plan for data of type T.
# Parameters correspond to 1e-7 accuracy.
# Note: sort_points ("sorting") is a bit misleading since it means permuting non-uniform
# locations.
params = (;
    block_size = 1024,      # set to `nothing` for default behaviour before PR30 (no spatial sorting; slower)
    sort_points = False(),  # doesn't change much (and needs a couple of extra GPU allocations)
)
p = PlanNUFFT(T, Ns; m = HalfSupport(4), σ = 2.0, backend, fftw_flags = FFTW.ESTIMATE, params...);

CUDA.@time set_points!(p, xp_tup);
# CUDA.@profile trace=true set_points!(p, xp_tup)
@btime CUDA.@sync set_points!($p, $xp_tup);   # 103ms (no sorting) / 109ms (sorting)

us = KernelAbstractions.zeros(backend, complex(T), size(p));

CUDA.@time exec_type1!(us, p, vp);
@btime CUDA.@sync exec_type1!($us, $p, $vp);  # 337ms (no sorting) / 332ms (sorting)

wp = similar(vp);

CUDA.@time exec_type2!(wp, p, us);  # 0.11s (blocking + sorting)
@btime CUDA.@sync exec_type2!($wp, $p, $us);  # 109ms (no sorting) / 112ms (sorting)

# Copy results to the CPU for making comparisons later.
us_ours = Array(us);
wp_ours = Array(wp);

## Compare with CuFINUFFT

using FINUFFT

opts = (
    modeord = 1,
    upsampfac = 2.0,
    gpu_device_id = CUDA.deviceid(CUDA.device()),
    gpu_stream = Base.unsafe_convert(Ptr{CUDA.CUstream_st}, CUDA.stream()),
    gpu_method = 1,  # 1: GM(-sort) method -- method 0 or 2 is much slower, at least with Float64 data
    gpu_sort = 1,    # needed for good performance
    gpu_kerevalmeth = 1,  # setting it to 0 (direct evaluation) doesn't make a big difference
)

ntrans = 1
n_modes = collect(Ns)
tol = 1e-7
plan_type1 = cufinufft_makeplan(1, n_modes, -1, ntrans, tol; dtype = Tr, opts...)
plan_type2 = cufinufft_makeplan(2, n_modes, +1, ntrans, tol; dtype = Tr, opts...)
finalizer(cufinufft_destroy!, plan_type1)
finalizer(cufinufft_destroy!, plan_type2)

CUDA.@time cufinufft_setpts!(plan_type1, xp_tup...);
CUDA.@time cufinufft_setpts!(plan_type2, xp_tup...);

@btime CUDA.@sync cufinufft_setpts!($plan_type1, $xp_tup...);  # 2.7ms with sorting (fast!!)

if us isa CuArray
    CUDA.@time cufinufft_exec!(plan_type1, vp, us);
    CUDA.@time cufinufft_exec!(plan_type2, us, wp);
    @btime CUDA.@sync cufinufft_exec!($plan_type1, $vp, $us);  # 279ms with sorting
    @btime CUDA.@sync cufinufft_exec!($plan_type2, $us, $wp);  # 105ms with sorting
end

##

us_finu = Array(us);
@show norm(us_ours - us_finu) / norm(us_ours)  # 1.55e-7

wp_finu = Array(wp);
@show norm(wp_ours - wp_finu) / norm(wp_ours)  # 1.58e-7
```