### PR TITLE
Make things work on AMD GPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Transforms now work on AMD GPUs.
+  This only required some minor modifications to some KA kernels.
+
 ## [v0.5.4] - 2024-09-25
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NonuniformFFTs"
 uuid = "cd96f58b-6017-4a02-bb9e-f4d81626177f"
 authors = ["Juan Ignacio Polanco <juan-ignacio.polanco@cnrs.fr>"]
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The only differences are:
 - we copy input arrays to the GPU before calling any NUFFT-related functions (`set_points!`, `exec_type1!`, `exec_type2!`)
 
 The example is for an Nvidia GPU (using [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl)), but should also work with e.g. [AMDGPU.jl](https://github.com/JuliaGPU/AMDGPU.jl)
-by simply choosing `backend = ROCBackend()` (this hasn't been tested yet).
+by simply choosing `backend = ROCBackend()`.
 
 ```julia
 using NonuniformFFTs

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -201,7 +201,7 @@ The only differences are:
 - we copy input arrays to the GPU before calling any NUFFT-related functions (`set_points!`, `exec_type1!`, `exec_type2!`)
 
 The example is for an Nvidia GPU (using [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl)), but should also work with e.g. [AMDGPU.jl](https://github.com/JuliaGPU/AMDGPU.jl)
-by simply choosing `backend = ROCBackend()` (this hasn't been tested yet).
+by simply choosing `backend = ROCBackend()`.
 
 ```julia
 using NonuniformFFTs

--- a/src/NonuniformFFTs.jl
+++ b/src/NonuniformFFTs.jl
@@ -350,8 +350,8 @@ end
     js = map(inbounds_getindex, index_map, is)  # input index
     ϕs_local = map(inbounds_getindex, ϕ̂s, is)   # convolution coefficients (one for each Cartesian direction)
     β = normfactor / prod(ϕs_local)
-    for (w, u) ∈ zip(ŵs_all, ûs_all)
-        @inbounds w[is...] = β * u[js...]
+    for n ∈ eachindex(ŵs_all, ûs_all)
+        @inbounds ŵs_all[n][is...] = β * ûs_all[n][js...]
     end
     nothing
 end
@@ -406,8 +406,8 @@ end
     js = map(inbounds_getindex, index_map, is)  # output index (on oversampled grid)
     ϕs_local = map(inbounds_getindex, ϕ̂s, is)   # convolution coefficients (one for each Cartesian direction)
     β = 1 / prod(ϕs_local)                      # deconvolution factor
-    for (ŵs, ûs) ∈ zip(ŵs_all, ûs_all)
-        @inbounds ûs[js...] = β * ŵs[is...]
+    for n ∈ eachindex(ŵs_all, ûs_all)
+        @inbounds ûs_all[n][js...] = β * ŵs_all[n][is...]
     end
     nothing
 end

--- a/src/NonuniformFFTs.jl
+++ b/src/NonuniformFFTs.jl
@@ -54,7 +54,7 @@ default_block_size(::Dims{2}, ::GPU) = (32, 32)
 default_block_size(::Dims{3}, ::GPU) = (16, 16, 4)  # tuned on A100 with 256³ non-oversampled grid, σ = 2 and m = HalfSupport(4)
 
 function default_workgroupsize(backend, ndrange::Dims)
-    # This currently assumes 1024 available threads, which might fail in some GPUs (AMD?).
+    # This currently assumes 1024 available threads, which might fail in some GPUs.
     KA.default_cpu_workgroupsize(ndrange)
 end
 


### PR DESCRIPTION
This only required some very minor modifications to KA kernels. Basically:

- AMDGPU doesn't like `zip` in kernels, so we use `eachindex` instead;
- AMDGPU doesn't like `map` calls iterating over 3 or more tuples at once, so we use `ntuple` instead;
- fixed an issue in spreading when the actual dataset size `Ns` depends on whether the output data is real or complex.

Transforms now work and give the right results on AMD GPUs. Tested on a laptop with an integrated AMD GPU (`AMD Ryzen 5 7640U w/ Radeon 760M Graphics`, `gfx1103`) and ROCm 6.1.2 / rocFFT 1.0.27 (from Fedora 40 repos).