### PR TITLE
Change default accuracy of transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This is disabled by default, and can be enabled by passing `gpu_method = :shared_memory`
   (default is `:global_memory`).
 
+### Changed
+
+- [BREAKING] Change default precision of transforms.
+  By default, transforms on `Float64` or `ComplexF64` now have a relative precision of the order of $10^{-7}$.
+  This corresponds to setting `m = HalfSupport(4)` and oversampling factor `σ = 2.0`.
+  Previously, the default was `m = HalfSupport(8)` and `σ = 2.0`, corresponding
+  to a relative precision of the order of $10^{-14}$.
+
 ## [v0.5.6](https://github.com/jipolanco/NonuniformFFTs.jl/releases/tag/v0.5.6) - 2024-10-17
 
 ### Changed

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -78,7 +78,10 @@ The created plan contains all data needed to perform NUFFTs for non-uniform data
 
 ## NUFFT parameters
 
-- `m = HalfSupport(8)`: the half-support of the convolution kernels. Large values
+The following parameters control transform accuracy. The default values give a relative accuracy of
+the order of ``10^{-7}`` for `Float64` or `ComplexF64` data.
+
+- `m = HalfSupport(4)`: the half-support of the convolution kernels. Large values
   increase accuracy at the cost of performance.
 
 - `σ = 2.0`: NUFFT oversampling factor. Typical values are 2.0 (more accurate) and 1.25 (faster),
@@ -421,7 +424,7 @@ end
 @inline to_static(ntrans::Int) = Val(ntrans)
 
 # This constructor relies on constant propagation to make the output fully inferred.
-Base.@constprop :aggressive function PlanNUFFT(::Type{T}, Ns::Dims; m = 8, kws...) where {T <: Number}
+Base.@constprop :aggressive function PlanNUFFT(::Type{T}, Ns::Dims; m = 4, kws...) where {T <: Number}
     h = to_halfsupport(m)
     PlanNUFFT(T, Ns, h; kws...)
 end


### PR DESCRIPTION
By default (if `m` and `σ` are not explicitly passed), the relative accuracy of the plans is now of the order of $10^{-7}$ instead of $10^{-14}$ for double precision data.