### PR TITLE
Spreading: use fine-grained locking for CPU threads

### DIFF
--- a/src/blocking/cpu.jl
+++ b/src/blocking/cpu.jl
@@ -5,6 +5,7 @@ struct BlockDataCPU{
         T,  # = real(Z)
         Buffers <: AbstractVector{<:NTuple{Nc, AbstractArray{Z, N}}},
         Indices <: CartesianIndices{N},
+        LockArray <: AbstractArray{<:Base.AbstractLock, N},
         SortPoints <: StaticBool,
     } <: AbstractBlockData
     # The following fields are the same as in BlockDataGPU:
@@ -19,6 +20,7 @@ struct BlockDataCPU{
     buffers :: Buffers            # length = nthreads
     blocks_per_thread :: Vector{Int}  # maps a set of blocks i_start:i_end to a thread (length = nthreads + 1)
     indices :: Indices    # index associated to each block (length = num_blocks)
+    locks_per_block :: LockArray  # fine-grained lock over a region of uniform array (spreading only)
 
     function BlockDataCPU(
             Δxs::NTuple{N, T},
@@ -34,9 +36,12 @@ struct BlockDataCPU{
         blockidx = similar(npoints_per_block, 0)
         pointperm = similar(npoints_per_block, 0)
         blocks_per_thread = similar(blockidx, Nt + 1)
-        new{Z, N, Nc, I, T, typeof(buffers), Indices, S}(
+        # Create one lock per output block.
+        block_indices = eachindex(IndexCartesian(), indices)  # (1:nblocks_x, 1:nblocks_y, ...)
+        locks_per_block = map(_ -> ReentrantLock(), block_indices)
+        new{Z, N, Nc, I, T, typeof(buffers), Indices, typeof(locks_per_block), S}(
             Δxs, nblocks_per_dir, block_dims, npoints_per_block, blockidx, pointperm, sort,
-            buffers, blocks_per_thread, indices,
+            buffers, blocks_per_thread, indices, locks_per_block,
         )
     end
 end
@@ -47,9 +52,12 @@ function BlockDataCPU(
     ) where {Z <: Number, D, M, Nc}
     @assert Nc > 0
     # Reduce block size if the actual dataset is too small.
-    # The block size must satisfy B ≤ N - M (this is assumed in spreading/interpolation).
+    # Conversely, increase it if the block size is smaller than the half-support M (to make
+    # sure that we only spread to closest blocks).
+    # The block size must satisfy M ≤ B ≤ N - M (this is assumed in spreading/interpolation).
     block_dims = map(Ñs, block_dims_in) do N, B
-        min(B, N - M)
+        @assert N >= 2M "oversampled grid should be larger than kernel width"
+        clamp(B, M, N - M)
     end
     nblocks_per_dir = map(cld, Ñs, block_dims)  # basically equal to ceil(Ñ / block_dim)
     T = real(Z)

--- a/src/spreading/cpu_blocked.jl
+++ b/src/spreading/cpu_blocked.jl
@@ -91,6 +91,28 @@ function to_real_array_cpu(u::Array{Complex{T}}) where {T <: Real}
     unsafe_wrap(Array, p, (2, size(u)...))::Array{T}
 end
 
+# Applies `f` to all blocks surrounding block I (including I itself).
+# Takes periodicity into account.
+function foreach_neighbouring_block(f::F, I::CartesianIndex, indices::CartesianIndices) where {F}
+    # checkbounds(indices, I)
+    blocks = map(_neighbouring_blocks, Tuple(I), axes(indices))
+    for js in Iterators.product(blocks...)
+        J = CartesianIndex(js)
+        # checkbounds(indices, J)
+        @inline f(J)
+    end
+    nothing
+end
+
+function _neighbouring_blocks(i::Int, ax::AbstractUnitRange)
+    # Assume that a block can only write to itself and its nearest neighbours.
+    # This requires the block size to be larger than the spreading kernel half-support M.
+    # (This is imposed by the BlockDataCPU constructor.)
+    l = i == first(ax) ? last(ax) : i - 1  # = i - 1 with periodic folding
+    r = i == last(ax) ? first(ax) : i + 1  # = i + 1 with periodic folding
+    (l, i, r)
+end
+
 function spread_from_points!(
         ::CPU,
         callback::Callback,
@@ -103,13 +125,14 @@ function spread_from_points!(
         vp_all::NTuple{C, AbstractVector};
         cpu_use_atomics::Bool = false,
     ) where {F <: Function, Callback <: Function, C, D}
-    (; block_dims, pointperm, buffers, indices,) = bd
+    (; block_dims, pointperm, buffers, indices, locks_per_block) = bd
     Ms = map(Kernels.half_support, gs)
     Nt = length(buffers)  # usually equal to the number of threads
     # nblocks = length(indices)
     Base.require_one_based_indexing(buffers)
     Base.require_one_based_indexing(indices)
-    lck = ReentrantLock()
+
+    block_indices = eachindex(IndexCartesian(), indices)  # (1:nblocks_x, 1:nblocks_y, ...)
 
     # Reinterpret output array as real-valued array if it's complex.
     # This is needed for performance if we're using atomics on complex data.
@@ -154,9 +177,19 @@ function spread_from_points!(
             if cpu_use_atomics
                 add_from_block!(us_real, block, inds_split; atomics = Val(true))
             else
-                # This is executed by only one thread at a time (might be slower for many threads)
-                lock(lck) do
+                I_block = block_indices[j]
+                try
+                    # Lock this block and neighbouring ones.
+                    # This assumes that block_dims ≥ M (see BlockDataCPU constructor).
+                    # In principle, if we block them from "left to right", there's no chance
+                    # for a deadlock.
+                    foreach_neighbouring_block(J -> lock(locks_per_block[J]), I_block, block_indices)
                     add_from_block!(us_all, block, inds_split; atomics = Val(false))
+                catch e
+                    rethrow(e)
+                finally
+                    # Unlock blocks.
+                    foreach_neighbouring_block(J -> unlock(locks_per_block[J]), I_block, block_indices)
                 end
             end
         end


### PR DESCRIPTION
Instead of using a single global lock to allow a thread to write its results, we now use a fine-grained approach which only locks the regions of the output arrays which will potentially be modified.

This is inspired by ducc's approach.